### PR TITLE
Update chroot-script.sh

### DIFF
--- a/builder/chroot-script.sh
+++ b/builder/chroot-script.sh
@@ -136,7 +136,7 @@ usermod -a -G video pirate
 printf "# Spawn a getty on Raspberry Pi serial line\nT0:23:respawn:/sbin/getty -L ttyAMA0 115200 vt100\n" >> /etc/inittab
 
 # boot/cmdline.txt
-echo "+dwc_otg.lpm_enable=0 console=tty1 root=/dev/mmcblk0p2 rootfstype=ext4 cgroup_enable=memory swapaccount=1 elevator=deadline fsck.repair=yes rootwait console=ttyAMA0,115200 kgdboc=ttyAMA0,115200" > /boot/cmdline.txt
+echo "+dwc_otg.lpm_enable=0 console=tty1 root=/dev/mmcblk0p2 rootfstype=ext4 cgroup_enable=cpuset cgroup_enable=memory swapaccount=1 elevator=deadline fsck.repair=yes rootwait console=ttyAMA0,115200 kgdboc=ttyAMA0,115200" > /boot/cmdline.txt
 
 # create a default boot/config.txt file (details see http://elinux.org/RPiconfig)
 echo "


### PR DESCRIPTION
Per https://github.com/kubernetes/kubernetes/issues/26038 this is needed to run kubelet on the RPi when installing https://github.com/kubernetes/kube-deploy/tree/master/docker-multinode. Would be nice to have this included by default since, I assume, this is a common use case.